### PR TITLE
OLISYS-4763: argo-sync app token + main-PR source check

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -14,8 +14,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate app token
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.OLI_ARGO_SYNC_CLIENT_ID }}
+          private-key: ${{ secrets.OLI_ARGO_SYNC_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Compute short SHA
         id: sha
@@ -64,8 +73,8 @@ jobs:
 
       - name: Commit and push
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "oli-argo-sync[bot]"
+          git config user.email "275810390+oli-argo-sync[bot]@users.noreply.github.com"
           git add infra/helm/
           git commit -m "chore: update ${{ github.ref_name }} image to ${{ github.ref_name }}-${{ steps.sha.outputs.short_sha }} [skip ci]"
           git push

--- a/.github/workflows/pr-source-check.yaml
+++ b/.github/workflows/pr-source-check.yaml
@@ -1,0 +1,17 @@
+name: PR Source Check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  pr-source-check:
+    name: PR source must be develop
+    runs-on: self-hosted
+    steps:
+      - name: Ensure PR source is develop
+        run: |
+          if [ "${{ github.head_ref }}" != "develop" ]; then
+            echo "::error::PRs to main must come from develop. Got '${{ github.head_ref }}'."
+            exit 1
+          fi

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -41,10 +41,18 @@ jobs:
     needs: build-and-push
 
     steps:
+      - name: Generate app token
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.OLI_ARGO_SYNC_CLIENT_ID }}
+          private-key: ${{ secrets.OLI_ARGO_SYNC_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           ref: main
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install yq
         run: |
@@ -60,8 +68,8 @@ jobs:
 
       - name: Commit and push
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "oli-argo-sync[bot]"
+          git config user.email "275810390+oli-argo-sync[bot]@users.noreply.github.com"
           git add infra/argo/prod.yaml
           git commit -m "chore: update prod to ${{ github.ref_name }}"
           git push


### PR DESCRIPTION
## Summary
- Switch CI write-back to `oli-argo-sync` GitHub App so ruleset-protected
  develop/main accept the pushes.
- Add `pr-source-check.yaml` so PRs to `main` must come from `develop`.

## Test plan
- [ ] On merge, next build-push run uses app token and commits as
      `oli-argo-sync[bot]`.
- [ ] PR opened to `main` from any branch other than `develop` fails the
      `PR source must be develop` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)