### PR TITLE
ci: stop build-push write-back from suppressing PR checks

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -8,6 +8,12 @@ on:
     branches:
       - main
       - develop
+    # The write-back commit below only touches infra/helm, so ignoring that
+    # path is what stops this workflow re-triggering itself. Using [skip ci]
+    # instead would also suppress the pull_request checks that the branch
+    # rulesets require, leaving develop -> main PRs blocked forever.
+    paths-ignore:
+      - "infra/helm/**"
 
 jobs:
   build-and-push:
@@ -76,7 +82,7 @@ jobs:
           git config user.name "oli-argo-sync[bot]"
           git config user.email "275810390+oli-argo-sync[bot]@users.noreply.github.com"
           git add infra/helm/
-          git commit -m "chore: update ${{ github.ref_name }} image to ${{ github.ref_name }}-${{ steps.sha.outputs.short_sha }} [skip ci]"
+          git commit -m "chore: update ${{ github.ref_name }} image to ${{ github.ref_name }}-${{ steps.sha.outputs.short_sha }}"
           git push
 
       - name: Connect to VPN


### PR DESCRIPTION
`build-push.yaml` write-back commits carry `[skip ci]` so the workflow does not re-trigger itself. GitHub also honours `[skip ci]` for `pull_request` events, so once that bot commit is the head of `develop`, no check runs are created for a `develop -> main` PR at all. The required status checks (`Build and Test`, `PR source must be develop`) then never report and the promotion PR stays blocked indefinitely -- see #26.

Replaces `[skip ci]` with `paths-ignore: infra/helm/**` on the push trigger. The write-back only touches `infra/helm/`, so the self-trigger is still prevented, but PR checks run normally.

Testing this on this repo first; if it clears #26 the same change goes to the other banula repos.