### PR TITLE
fix: expose ingress routes in prod values

### DIFF
--- a/infra/helm/values.prod.yaml
+++ b/infra/helm/values.prod.yaml
@@ -11,3 +11,8 @@ oli-app:
       - secretName: banula-tls
         hosts:
           - banula.oli-system.com
+    features:
+      router:
+        routes:
+          exposeCommon: false
+          exposeAll: true


### PR DESCRIPTION
`tariff-manager-prod` has failed to sync since its first prod release:

```
Ingress.networking.k8s.io "tariff-manager-prod" is invalid:
spec.rules[0].http.paths: Required value
```

`values.prod.yaml` sets `hosts` and `tls` but never overrides the router routes, so it inherits `exposeCommon: false` / `exposeAll: false` from `values.yaml`. With no manual paths and both flags off, `paths:` renders empty and the API server rejects the object. `values.int.yaml` already has this block -- prod was the only one missing it.

Renders to a single catch-all matching the service's own `SERVER_CONTEXT_PATH`:

```yaml
paths:
  - path: /tariff-manager(/|$)(.*)
    pathType: ImplementationSpecific
```

Same fix as olisystems/ocn-node-v2#76.