### PR TITLE
chore: promote develop to main

### DIFF
--- a/infra/helm/values.prod.yaml
+++ b/infra/helm/values.prod.yaml
@@ -11,3 +11,8 @@ oli-app:
       - secretName: banula-tls
         hosts:
           - banula.oli-system.com
+    features:
+      router:
+        routes:
+          exposeCommon: false
+          exposeAll: true


### PR DESCRIPTION
Carries the prod ingress fix from #28 so `tariff-manager-prod` can sync again.

```
Ingress.networking.k8s.io "tariff-manager-prod" is invalid:
spec.rules[0].http.paths: Required value
```

`values.prod.yaml` set `hosts` and `tls` but never overrode the router routes, so it inherited `exposeCommon: false` / `exposeAll: false` from `values.yaml` and the Ingress rendered with an empty `paths:`. Renders to `/tariff-manager(/|$)(.*)`, matching the service's own `SERVER_CONTEXT_PATH`.

Same fix as olisystems/ocn-node-v2#77.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Promotes `develop` to `main`.
- Adds production router feature exposure in `infra/helm/values.prod.yaml`.
- Disables common route exposure and enables all routes.
- Renders the ingress route as `/tariff-manager(/|$)(.*)`.
- Aligns the ingress route with `SERVER_CONTEXT_PATH`.
- Prevents an empty `spec.rules[0].http.paths` configuration and related Kubernetes validation failures.

## Aditional info from review-info MCP

| Field | Value |
|-------|-------|
| **Found** | ✅ `true` |
| **Repository** | `tariff-manager` |
| **Project** | **Transit** (`transit`) |

### Repository Description

Tariff management service for an EV charging and roaming platform.

## Project Description

The **Transit** project is an EV charging and roaming platform implementing **OCPI 2.2.1** and **OCPP 1.6** protocols.

It consists of a distributed microservices architecture supporting:

- CPO/eMSP operations
- Billing
- Tariff management
- Roaming through the OCN node
- Admin dashboards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->