### PR TITLE
OLISYS-4913 fix(ci): sanitize branch name into a valid docker tag in override-dev

### DIFF
--- a/.github/workflows/override-dev.yaml
+++ b/.github/workflows/override-dev.yaml
@@ -12,9 +12,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Compute short SHA
+      - name: Compute short SHA and safe tag
         id: sha
-        run: echo "short_sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+        run: |
+          echo "short_sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+          # Docker tags only allow [A-Za-z0-9_.-], so branch names like feat/foo need sanitizing
+          safe_ref=$(printf '%s' "$GITHUB_REF_NAME" | tr -c 'A-Za-z0-9_.-' '-' | cut -c1-128)
+          echo "safe_ref=$safe_ref" >> $GITHUB_OUTPUT
 
       - name: Login to SWR
         uses: docker/login-action@v3
@@ -38,7 +42,7 @@ jobs:
           cache-to: type=gha,mode=max
           tags: |
             swr.eu-de.otc.t-systems.com/oli_banula/tariff-manager:latest
-            swr.eu-de.otc.t-systems.com/oli_banula/tariff-manager:${{ github.ref_name }}
+            swr.eu-de.otc.t-systems.com/oli_banula/tariff-manager:${{ steps.sha.outputs.safe_ref }}
             swr.eu-de.otc.t-systems.com/oli_banula/tariff-manager:develop-${{ steps.sha.outputs.short_sha }}
             swr.eu-de.otc.t-systems.com/oli_banula/tariff-manager:${{ steps.sha.outputs.short_sha }}
 


### PR DESCRIPTION
The `Override Dev` workflow puts `${{ github.ref_name }}` straight into the
Docker tag list. Docker tags only allow `[A-Za-z0-9_.-]`, so the build-push
step fails for any branch with a `/` in it (e.g. `feat/foo`).

The branch name is now sanitized into a `safe_ref` value that is used for the
image tag. The ArgoCD patch keeps the raw `github.ref_name` for
`spec.source.targetRevision`, since that is a git ref and must not be sanitized.

Part of the OLISYS-4913 rollout across the ArgoCD-backed repos.
Reference implementation: olisystems/banula-bff-service#62

🤖 Generated with [Claude Code](https://claude.com/claude-code)