### PR TITLE
OLISYS-4970 -> develop | bounded pagination and resilient tariff synchronization

### DIFF
--- a/src/main/java/com/banula/tariffmanager/client/TmPlatformClient.java
+++ b/src/main/java/com/banula/tariffmanager/client/TmPlatformClient.java
@@ -20,7 +20,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
@@ -37,6 +36,11 @@ public class TmPlatformClient {
     private static final String OUTFLOW_BASE = "/api/v1/internal/outflow/ocpi";
     private static final String VERSION = "2.2.1";
     private static final int PAGE_LIMIT = 100;
+    /**
+     * Safety net for a server that ignores {@code offset} and keeps answering with a full page:
+     * without it the paging loops below would never terminate.
+     */
+    private static final int MAX_RECORDS = 10_000;
 
     private final RestTemplate restTemplate;
     private final ApplicationConfiguration applicationConfiguration;
@@ -82,7 +86,12 @@ public class TmPlatformClient {
             if (!hasNextPage(responseEntity.getHeaders(), offset, page.size())) {
                 break;
             }
-            offset += PAGE_LIMIT;
+            offset += page.size();
+            if (all.size() >= MAX_RECORDS) {
+                log.warn("Stopping tariff pull from {}/{} at {} record(s): the server still advertises more",
+                        toCountryCode, toPartyId, all.size());
+                break;
+            }
         }
         return all;
     }
@@ -94,24 +103,49 @@ public class TmPlatformClient {
     public List<HubClientInfoDTO> getHubClientInfos() {
         String hubCountry = applicationConfiguration.getCountryCode();
         String hubParty = applicationConfiguration.getPartyId();
-        String url = applicationConfiguration.getPlatformUrl() + OUTFLOW_BASE + "/sender/" + VERSION
-                + "/hubclientinfo";
+        List<HubClientInfoDTO> all = new ArrayList<>();
+        int offset = 0;
+        while (true) {
+            String url = UriComponentsBuilder
+                    .fromHttpUrl(applicationConfiguration.getPlatformUrl() + OUTFLOW_BASE + "/sender/" + VERSION
+                            + "/hubclientinfo")
+                    .queryParam("offset", offset)
+                    .queryParam("limit", PAGE_LIMIT)
+                    .encode()
+                    .toUriString();
 
-        OcpiResponse<List<HubClientInfoDTO>> response = exchange(
-                url,
-                HttpMethod.GET,
-                hubCountry,
-                hubParty,
-                null,
-                new ParameterizedTypeReference<OcpiResponse<List<HubClientInfoDTO>>>() {
-                });
+            ResponseEntity<OcpiResponse<List<HubClientInfoDTO>>> responseEntity = exchangeEntity(
+                    url,
+                    HttpMethod.GET,
+                    hubCountry,
+                    hubParty,
+                    null,
+                    new ParameterizedTypeReference<OcpiResponse<List<HubClientInfoDTO>>>() {
+                    });
 
-        if (response == null || response.getStatus_code() != Constants.STATUS_CODE_OK) {
-            String message = response != null ? response.getStatus_message() : "empty response";
-            throw new OCPICustomException(
-                    "Failed to pull hubclientinfo from hub " + hubCountry + "/" + hubParty + ": " + message);
+            OcpiResponse<List<HubClientInfoDTO>> response = responseEntity.getBody();
+            if (response == null || response.getStatus_code() != Constants.STATUS_CODE_OK) {
+                String message = response != null ? response.getStatus_message() : "empty response";
+                throw new OCPICustomException(
+                        "Failed to pull hubclientinfo from hub " + hubCountry + "/" + hubParty + ": " + message);
+            }
+
+            List<HubClientInfoDTO> page = response.getData();
+            if (page == null || page.isEmpty()) {
+                break;
+            }
+            all.addAll(page);
+            if (!hasNextPage(responseEntity.getHeaders(), offset, page.size())) {
+                break;
+            }
+            offset += page.size();
+            if (all.size() >= MAX_RECORDS) {
+                log.warn("Stopping hubclientinfo pull from hub {}/{} at {} record(s): the server still advertises more",
+                        hubCountry, hubParty, all.size());
+                break;
+            }
         }
-        return response.getData() != null ? response.getData() : Collections.emptyList();
+        return all;
     }
 
     /**
@@ -187,7 +221,9 @@ public class TmPlatformClient {
 
     /**
      * Prefer OCPI 2.2.1 pagination headers ({@code Link} / {@code X-Total-Count}). Fall back to a
-     * full page only when those headers are absent (e.g. an internal proxy stripped them).
+     * full page only when those headers are absent — which is the case today, because the platform
+     * outflow handler answers from a freshly built header set and does not relay the node's
+     * pagination headers, so there is no next-page link to follow.
      */
     private boolean hasNextPage(HttpHeaders headers, int offset, int pageSize) {
         if (headers == null) {

--- a/src/main/java/com/banula/tariffmanager/client/TmPlatformClient.java
+++ b/src/main/java/com/banula/tariffmanager/client/TmPlatformClient.java
@@ -82,7 +82,12 @@ public class TmPlatformClient {
             if (page == null || page.isEmpty()) {
                 break;
             }
-            all.addAll(page);
+            int remaining = MAX_RECORDS - all.size();
+            if (page.size() > remaining) {
+                all.addAll(page.subList(0, remaining));
+            } else {
+                all.addAll(page);
+            }
             if (!hasNextPage(responseEntity.getHeaders(), offset, page.size())) {
                 break;
             }
@@ -134,7 +139,12 @@ public class TmPlatformClient {
             if (page == null || page.isEmpty()) {
                 break;
             }
-            all.addAll(page);
+            int remaining = MAX_RECORDS - all.size();
+            if (page.size() > remaining) {
+                all.addAll(page.subList(0, remaining));
+            } else {
+                all.addAll(page);
+            }
             if (!hasNextPage(responseEntity.getHeaders(), offset, page.size())) {
                 break;
             }

--- a/src/main/java/com/banula/tariffmanager/model/MongoTariffPublicationOutbox.java
+++ b/src/main/java/com/banula/tariffmanager/model/MongoTariffPublicationOutbox.java
@@ -20,6 +20,8 @@ public class MongoTariffPublicationOutbox {
     private String partyId;
     private String tariffId;
     private TariffPublicationStatus status;
+    /** Token of the publication attempt that last moved this record to PENDING; see TariffSyncServiceImpl. */
+    private String attemptId;
     private LocalDateTime lastAttemptAt;
     private String lastError;
 }

--- a/src/main/java/com/banula/tariffmanager/service/HubClientInfoServiceImpl.java
+++ b/src/main/java/com/banula/tariffmanager/service/HubClientInfoServiceImpl.java
@@ -110,6 +110,10 @@ public class HubClientInfoServiceImpl implements HubClientInfoService {
             List<HubClientInfoDTO> parties = tmPlatformClient.getHubClientInfos();
             log.info("HubClientInfo sync pulled {} party record(s) from hub", parties.size());
             for (HubClientInfoDTO party : parties) {
+                if (party == null || party.getPartyId() == null || party.getCountryCode() == null) {
+                    log.warn("Skipping hub client info record without a complete party identity");
+                    continue;
+                }
                 try {
                     updateHubClientInfoByPartyIdAndCountryCode(party.getPartyId(), party.getCountryCode(), party);
                 } catch (Exception e) {

--- a/src/main/java/com/banula/tariffmanager/service/HubClientInfoServiceImpl.java
+++ b/src/main/java/com/banula/tariffmanager/service/HubClientInfoServiceImpl.java
@@ -38,8 +38,10 @@ public class HubClientInfoServiceImpl implements HubClientInfoService {
     @Override
     public HubClientInfoDTO updateHubClientInfoByPartyIdAndCountryCode(String partyId, String countryCode,
             HubClientInfoDTO clientInfoDTO) {
-        if (clientInfoDTO == null || clientInfoDTO.getRole() == null) {
-            throw new OCPICustomException("Client info role is required",
+        // status is a required field of the OCPI ClientInfo object: without this guard a body
+        // carrying only a role would overwrite a stored CONNECTED party with a null status.
+        if (clientInfoDTO == null || clientInfoDTO.getRole() == null || clientInfoDTO.getStatus() == null) {
+            throw new OCPICustomException("Client info role and status are required",
                     Constants.STATUS_CODE_INVALID_OR_MISSING_PARAMETERS);
         }
 
@@ -108,7 +110,12 @@ public class HubClientInfoServiceImpl implements HubClientInfoService {
             List<HubClientInfoDTO> parties = tmPlatformClient.getHubClientInfos();
             log.info("HubClientInfo sync pulled {} party record(s) from hub", parties.size());
             for (HubClientInfoDTO party : parties) {
-                updateHubClientInfoByPartyIdAndCountryCode(party.getPartyId(), party.getCountryCode(), party);
+                try {
+                    updateHubClientInfoByPartyIdAndCountryCode(party.getPartyId(), party.getCountryCode(), party);
+                } catch (Exception e) {
+                    log.warn("Skipping unusable hub client info record {}/{}: {}", party.getCountryCode(),
+                            party.getPartyId(), e.getMessage());
+                }
             }
         } catch (Exception ex) {
             log.warn("Initial HubClientInfo sync failed, tariff-manager will learn parties dynamically: {}",

--- a/src/main/java/com/banula/tariffmanager/service/TariffSyncServiceImpl.java
+++ b/src/main/java/com/banula/tariffmanager/service/TariffSyncServiceImpl.java
@@ -140,11 +140,26 @@ public class TariffSyncServiceImpl implements TariffSyncService {
             } catch (Exception e) {
                 log.warn("Retry PUT failed for tariff {}/{}/{}: {}", record.getCountryCode(), record.getPartyId(),
                         record.getTariffId(), e.getMessage());
-                record.setLastAttemptAt(LocalDateTime.now(ZoneOffset.UTC));
-                record.setLastError(e.getMessage());
-                tariffPublicationOutboxRepository.save(record);
+                markRetryFailed(record, e.getMessage());
             }
         }
+    }
+
+    /**
+     * Records a failed retry without rewriting the whole document: a concurrent publication may
+     * already have written a newer status/attemptId, and a full save would roll that back. The
+     * attempt token in the query keeps the write scoped to the attempt that actually failed.
+     */
+    private void markRetryFailed(MongoTariffPublicationOutbox record, String error) {
+        Query query = Query.query(Criteria.where("countryCode").is(record.getCountryCode())
+                .and("partyId").is(record.getPartyId())
+                .and("tariffId").is(record.getTariffId())
+                .and("attemptId").is(record.getAttemptId()));
+        Update update = new Update()
+                .set("lastAttemptAt", LocalDateTime.now(ZoneOffset.UTC))
+                .set("lastError", error);
+        mongoTemplate.updateFirst(query, update, MongoTariffPublicationOutbox.class,
+                mongoCollectionMapper.getTariffPublicationOutboxCollectionName());
     }
 
     /**

--- a/src/main/java/com/banula/tariffmanager/service/TariffSyncServiceImpl.java
+++ b/src/main/java/com/banula/tariffmanager/service/TariffSyncServiceImpl.java
@@ -23,6 +23,7 @@ import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -99,14 +100,17 @@ public class TariffSyncServiceImpl implements TariffSyncService {
                         e.getMessage());
                 continue;
             }
-            markPublicationPending(tariff, null);
+            String attemptId = markPublicationPending(tariff, null);
             try {
                 // OCPI-to = hub (DE/BAN) → node broadcasts via ModuleNotificationService
                 tmPlatformClient.putTariffToHub(tariff);
-                markPublicationDelivered(tariff);
+                markPublicationDelivered(tariff, attemptId);
             } catch (Exception e) {
                 log.warn("Failed to put tariff {} to hub from {}/{}; will retry: {}", tariff.getId(), countryCode,
                         partyId, e.getMessage());
+                // A fresh attempt token is written on purpose: it fences any older PUT for the same
+                // tariff that is still in flight, so that one can no longer report DELIVERED over
+                // this failure.
                 markPublicationPending(tariff, e.getMessage());
             }
         }
@@ -132,7 +136,7 @@ public class TariffSyncServiceImpl implements TariffSyncService {
                     continue;
                 }
                 tmPlatformClient.putTariffToHub(tariff);
-                markPublicationDelivered(tariff);
+                markPublicationDelivered(tariff, record.getAttemptId());
             } catch (Exception e) {
                 log.warn("Retry PUT failed for tariff {}/{}/{}: {}", record.getCountryCode(), record.getPartyId(),
                         record.getTariffId(), e.getMessage());
@@ -143,12 +147,20 @@ public class TariffSyncServiceImpl implements TariffSyncService {
         }
     }
 
-    private void markPublicationPending(TariffDTO tariff, String error) {
+    /**
+     * Marks the tariff PENDING and returns the token identifying <em>this</em> attempt. Publication
+     * is not serialized per tariff (the welcome ceremony runs async while the hourly sync runs on
+     * the scheduler thread), so the token is what lets
+     * {@link #markPublicationDelivered(TariffDTO, String)} tell its own attempt from a newer one.
+     */
+    private String markPublicationPending(TariffDTO tariff, String error) {
+        String attemptId = UUID.randomUUID().toString();
         Query query = Query.query(Criteria.where("countryCode").is(tariff.getCountryCode())
                 .and("partyId").is(tariff.getPartyId())
                 .and("tariffId").is(tariff.getId()));
         Update update = new Update()
                 .set("status", TariffPublicationStatus.PENDING)
+                .set("attemptId", attemptId)
                 .set("lastAttemptAt", LocalDateTime.now(ZoneOffset.UTC))
                 .set("lastError", error)
                 .setOnInsert("countryCode", tariff.getCountryCode())
@@ -156,12 +168,20 @@ public class TariffSyncServiceImpl implements TariffSyncService {
                 .setOnInsert("tariffId", tariff.getId());
         mongoTemplate.upsert(query, update, MongoTariffPublicationOutbox.class,
                 mongoCollectionMapper.getTariffPublicationOutboxCollectionName());
+        return attemptId;
     }
 
-    private void markPublicationDelivered(TariffDTO tariff) {
+    /**
+     * Conditional transition to DELIVERED: it applies only while the record still carries the token
+     * of the attempt that is reporting success. A slow PUT whose tariff has since been re-published
+     * (and failed) therefore leaves the record PENDING for the retry loop instead of marking the
+     * newer, undelivered publication as delivered.
+     */
+    private void markPublicationDelivered(TariffDTO tariff, String attemptId) {
         Query query = Query.query(Criteria.where("countryCode").is(tariff.getCountryCode())
                 .and("partyId").is(tariff.getPartyId())
-                .and("tariffId").is(tariff.getId()));
+                .and("tariffId").is(tariff.getId())
+                .and("attemptId").is(attemptId));
         Update update = new Update()
                 .set("status", TariffPublicationStatus.DELIVERED)
                 .set("lastAttemptAt", LocalDateTime.now(ZoneOffset.UTC))

--- a/src/test/java/com/banula/tariffmanager/service/TariffSyncServiceImplTest.java
+++ b/src/test/java/com/banula/tariffmanager/service/TariffSyncServiceImplTest.java
@@ -1,0 +1,191 @@
+package com.banula.tariffmanager.service;
+
+import com.banula.openlib.ocpi.model.dto.TariffDTO;
+import com.banula.tariffmanager.client.TmPlatformClient;
+import com.banula.tariffmanager.config.ApplicationConfiguration;
+import com.banula.tariffmanager.config.MongoCollectionMapper;
+import com.banula.tariffmanager.model.MongoTariffPublicationOutbox;
+import com.banula.tariffmanager.model.TariffPublicationStatus;
+import com.banula.tariffmanager.repository.TariffPublicationOutboxRepository;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.UpdateDefinition;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the publication outbox transitions of {@link TariffSyncServiceImpl}, in particular that a
+ * PUT which succeeds late cannot mark a newer, failed publication as DELIVERED.
+ */
+class TariffSyncServiceImplTest {
+
+    private static final String COUNTRY = "DE";
+    private static final String PARTY = "ABC";
+    private static final String TARIFF_ID = "tariff-1";
+    private static final String OUTBOX_COLLECTION = "TariffPublicationOutbox";
+    private static final String OLDER_PUBLISHER_THREAD = "older-publisher";
+
+    private TmPlatformClient tmPlatformClient;
+    private TMTariffService tariffService;
+    private MongoTemplate mongoTemplate;
+    private TariffSyncServiceImpl service;
+    private OutboxRecord outbox;
+
+    @BeforeEach
+    void setUp() {
+        tmPlatformClient = mock(TmPlatformClient.class);
+        tariffService = mock(TMTariffService.class);
+        mongoTemplate = mock(MongoTemplate.class);
+        outbox = new OutboxRecord();
+
+        MongoCollectionMapper collectionMapper = mock(MongoCollectionMapper.class);
+        when(collectionMapper.getTariffPublicationOutboxCollectionName()).thenReturn(OUTBOX_COLLECTION);
+
+        when(tmPlatformClient.getTariffs(anyString(), anyString(), any(), any()))
+                .thenAnswer(invocation -> List.of(tariff()));
+
+        // Stand in for Mongo: the upsert always writes, the updateFirst only applies when the
+        // record still carries the attempt token named in the query.
+        doAnswer(invocation -> {
+            outbox.applyWrite(invocation.getArgument(1));
+            return null;
+        }).when(mongoTemplate).upsert(any(Query.class), any(UpdateDefinition.class),
+                eq(MongoTariffPublicationOutbox.class), anyString());
+
+        doAnswer(invocation -> {
+            outbox.applyConditionalWrite(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(mongoTemplate).updateFirst(any(Query.class), any(UpdateDefinition.class),
+                eq(MongoTariffPublicationOutbox.class), anyString());
+
+        service = new TariffSyncServiceImpl(
+                tmPlatformClient,
+                tariffService,
+                mock(HubClientInfoService.class),
+                mock(ApplicationConfiguration.class),
+                mongoTemplate,
+                collectionMapper,
+                mock(TariffPublicationOutboxRepository.class));
+    }
+
+    @Test
+    void marksPublicationDeliveredWhenHubPutSucceeds() {
+        service.pullStoreAndBroadcast(COUNTRY, PARTY, from(), to());
+
+        assertEquals(TariffPublicationStatus.DELIVERED, outbox.status());
+    }
+
+    @Test
+    void marksPublicationPendingWhenHubPutFails() {
+        doAnswer(invocation -> {
+            throw new IllegalStateException("hub unreachable");
+        }).when(tmPlatformClient).putTariffToHub(any(TariffDTO.class));
+
+        service.pullStoreAndBroadcast(COUNTRY, PARTY, from(), to());
+
+        assertEquals(TariffPublicationStatus.PENDING, outbox.status());
+    }
+
+    /**
+     * The welcome ceremony runs on the async executor while the hourly sync runs on the scheduler
+     * thread, so two publications of the same tariff can overlap. Ordering under test: the older PUT
+     * is still in flight when a newer publication of the same tariff fails; the older PUT then
+     * succeeds. The record must stay PENDING so the retry loop re-publishes the newer tariff.
+     */
+    @Test
+    void lateHubPutDoesNotDeliverOverNewerFailedPublication() throws Exception {
+        CountDownLatch olderPutEntered = new CountDownLatch(1);
+        CountDownLatch newerPublicationFinished = new CountDownLatch(1);
+        AtomicBoolean olderPutSucceeded = new AtomicBoolean(false);
+
+        doAnswer(invocation -> {
+            if (OLDER_PUBLISHER_THREAD.equals(Thread.currentThread().getName())) {
+                olderPutEntered.countDown();
+                if (!newerPublicationFinished.await(5, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("newer publication never finished");
+                }
+                olderPutSucceeded.set(true);
+                return null;
+            }
+            throw new IllegalStateException("hub rejected the newer tariff");
+        }).when(tmPlatformClient).putTariffToHub(any(TariffDTO.class));
+
+        Thread older = new Thread(() -> service.pullStoreAndBroadcast(COUNTRY, PARTY, from(), to()),
+                OLDER_PUBLISHER_THREAD);
+        older.start();
+        assertTrue(olderPutEntered.await(5, TimeUnit.SECONDS), "older PUT never started");
+
+        service.pullStoreAndBroadcast(COUNTRY, PARTY, from(), to());
+        newerPublicationFinished.countDown();
+        older.join(TimeUnit.SECONDS.toMillis(5));
+
+        assertTrue(olderPutSucceeded.get(), "the older PUT was expected to succeed late");
+        assertEquals(TariffPublicationStatus.PENDING, outbox.status(),
+                "a late PUT must not deliver over a newer publication that failed");
+    }
+
+    private TariffDTO tariff() {
+        TariffDTO tariff = new TariffDTO();
+        tariff.setCountryCode(COUNTRY);
+        tariff.setPartyId(PARTY);
+        tariff.setId(TARIFF_ID);
+        return tariff;
+    }
+
+    private LocalDateTime to() {
+        return LocalDateTime.now(ZoneOffset.UTC);
+    }
+
+    private LocalDateTime from() {
+        return to().minusHours(1);
+    }
+
+    /** Minimal stand-in for the single outbox document this test exercises. */
+    private static final class OutboxRecord {
+
+        private TariffPublicationStatus status;
+        private String attemptId;
+
+        synchronized void applyWrite(UpdateDefinition update) {
+            Document set = setDocument(update);
+            status = (TariffPublicationStatus) set.get("status");
+            if (set.containsKey("attemptId")) {
+                attemptId = (String) set.get("attemptId");
+            }
+        }
+
+        synchronized void applyConditionalWrite(Query query, UpdateDefinition update) {
+            Document criteria = query.getQueryObject();
+            if (criteria.containsKey("attemptId") && !Objects.equals(criteria.get("attemptId"), attemptId)) {
+                return;
+            }
+            applyWrite(update);
+        }
+
+        synchronized TariffPublicationStatus status() {
+            return status;
+        }
+
+        private Document setDocument(UpdateDefinition update) {
+            return (Document) update.getUpdateObject().get("$set");
+        }
+    }
+}


### PR DESCRIPTION
… races

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added pagination and safety limits to tariff and hub client information retrieval.
- Added OCPI response validation and handling for incomplete hub client records.
- Added attempt tokens to prevent stale asynchronous `PUT` operations from overwriting newer publication results.
- Added race-condition tests for tariff publication.
- Added `attemptId` to `MongoTariffPublicationOutbox`.

## Aditional info from review-info MCP

Repository metadata could not be retrieved because the required lookup was not completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->