### PR TITLE
Merge develop into main

### DIFF
--- a/infra/helm/images.dev.yaml
+++ b/infra/helm/images.dev.yaml
@@ -1,4 +1,4 @@
 # THIS FILE IS MANAGED BY ARGO + GITHUB ACTIONS
 oli-app:
   image:
-    tag: "develop-ecf956c"
+    tag: "develop-1187533"

--- a/infra/helm/values.prod.yaml
+++ b/infra/helm/values.prod.yaml
@@ -3,3 +3,17 @@ oli-app:
 
   image:
     tag: "v0.1.0"
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 448Mi
+    limits:
+      cpu: 500m
+      memory: 768Mi
+
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 70

--- a/infra/helm/values.yaml
+++ b/infra/helm/values.yaml
@@ -1,14 +1,5 @@
 oli-app:
-  replicaCount: 1
-
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
-      maxSurge: 1
-
   restartPolicy: Always
-  terminationGracePeriodSeconds: 45
 
   image:
     repository: "swr.eu-de.otc.t-systems.com/oli_banula/tariff-manager"
@@ -70,24 +61,26 @@ oli-app:
       memory: 512Mi
       cpu: 500m
 
+  startupProbe:
+    httpGet:
+      path: /health
+      port: http
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 24
+
   livenessProbe:
     httpGet:
       path: /health
       port: http
-    initialDelaySeconds: 60
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
 
   readinessProbe:
     httpGet:
       path: /health
       port: http
-    initialDelaySeconds: 30
-
-  autoscaling:
-    enabled: true
-    minReplicas: 1
-    maxReplicas: 1
-    targetCPUUtilizationPercentage: 90
-
-  podDisruptionBudget:
-    enabled: true
-    minAvailable: 1
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated the development `oli-app` image tag to `develop-1187533`.
- Added production resource requests, limits, and CPU-based autoscaling from 1 to 5 replicas at 70% utilization.
- Updated default Helm probes and removed default replica, rollout, termination, autoscaling, and pod disruption settings.
- Added a startup probe.

## Aditional info from review-info MCP

| Field | Value |
|-------|-------|
| **Found** | ✅ `true` |
| **Repository** | `banula-tariff-manager` |
| **Project** | **Transit** (`transit`) |

### Repository Description

Go service managing tariff definitions and pricing rules. Handles tariff creation, versioning, and distribution to CPO/eMSP services. Implements the OCPI Tariff module. Uses MongoDB.

### Project Description

The **Transit** project is an EV charging and roaming platform implementing **OCPI 2.2.1** and **OCPP 1.6** protocols. It uses a distributed microservices architecture for CPO/eMSP operations, billing, tariff management, roaming, and admin dashboards. It is deployed in Kubernetes with MongoDB and PostgreSQL backends.

### Review Instructions

- Verify OCPI/OCPP implementations against OCPI 2.2.1-d2 and OCPP 1.6.
- Apply strict OCPI compliance to `*/ocpi/<version>/<module>*` paths and nested resources.
- Route BFF frontend requests through `/api/v1/protected/*`.
- Namespace MongoDB collections by service.
- Use PostgreSQL only for contract-management and ocn-node.
- Verify `banula-open-library` and `private-lib` version compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->